### PR TITLE
Fix bitbucket ssh user name

### DIFF
--- a/src/codebackup/__init__.py
+++ b/src/codebackup/__init__.py
@@ -72,7 +72,7 @@ class Bitbucket(object):
 
 class HGRepository(Repository):
 
-    CLONE_URL = 'ssh://bitbucket.org/{self.site.username}/{self.name}/'
+    CLONE_URL = 'ssh://hg@bitbucket.org/{self.site.username}/{self.name}/'
     CLONE_CMD = 'hg clone -U {url} .'
     UPDATE_CMD = 'hg pull {url}'
 


### PR DESCRIPTION
When not fixing the user name, backup only works if run as use hg.
